### PR TITLE
Add Magic Shorts to video

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -5694,6 +5694,13 @@
           "date-added": "2023-12-31"
         },
         {
+          "title": "Magic Shorts",
+          "body": "AI faceless short-form videos",
+          "tag": "From $15/mo",
+          "url": "https://magicshorts.ai?ref=riseofmachine.com",
+          "date-added": "2025-06-30"
+        },
+        {
           "title": "Moonvalley",
           "body": "Text-to-video generative AI model.",
           "tag": "Beta",


### PR DESCRIPTION
Magic Shorts was added to the appropriate "video" category, adhering to formatting guidelines for the title, body, URL, and pricing tag. The entry is sorted alphabetically within the video category.