### PR TITLE
Add shipsquad.space to Xtras

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -7191,6 +7191,13 @@
           "date-added": "2025-06-29"
         },
         {
+          "title": "ShipSquad",
+          "body": "Not just another product listing site.",
+          "tag": "Free",
+          "url": "https://shipsquad.space/?ref=riseofmachine.com",
+          "date-added": "2025-08-30"
+        },
+        {
           "title": "StoryBox",
           "body": "Create stories with AI.",
           "tag": "Freemium",


### PR DESCRIPTION
#358


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Social Media tool: ShipSquad.
    - Title: ShipSquad
    - Tagline: “Not just another product listing site.”
    - Pricing tag: Free
    - Link: https://shipsquad.space/?ref=riseofmachine.com
    - Date added: 2025-08-30
  * Users can now discover ShipSquad in the Social Media tools list, expanding options for exploring product listing platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->