### PR TITLE
Add LandscapioAI

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -2117,6 +2117,14 @@
           "slug": "kittl"
         },
         {
+          "title": "LandscapioAI",
+          "body": "Free AI landscape design generator for yards and gardens.",
+          "tag": "Free",
+          "url": "https://www.landscapioai.com/?ref=riseofmachine.com",
+          "date-added": "2026-05-21",
+          "slug": "landscapioai"
+        },
+        {
           "title": "Logo Galleria",
           "body": "AI logo maker.",
           "tag": "Freemium",


### PR DESCRIPTION
## Summary
- Add LandscapioAI (https://www.landscapioai.com/) to this AI tools directory/list.
- LandscapioAI is a free AI landscape design generator for realistic outdoor redesign concepts, cost estimates, contractor-ready plans, and residential or commercial landscape ideas.

## Checks
- bun run check-data passed; git diff --check passed.
- Confirmed the patch mentions LandscapioAI and landscapioai.com.