### PR TITLE
Add agent-qa developer tool

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -2531,7 +2531,7 @@
       "category": "developer",
       "content": [
         {
-          "title": "agent-qa",
+          "title": "Agent QA",
           "body": "Self-improving agent for software quality.",
           "tag": "Free",
           "url": "https://github.com/vostride/agent-qa?ref=riseofmachine.com",

--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -2531,6 +2531,14 @@
       "category": "developer",
       "content": [
         {
+          "title": "agent-qa",
+          "body": "Self-improving agent for software quality.",
+          "tag": "Free",
+          "url": "https://github.com/vostride/agent-qa?ref=riseofmachine.com",
+          "date-added": "2026-08-15",
+          "slug": "agent-qa"
+        },
+        {
           "title": "Amazon Codewhisperer",
           "body": "A code writing assistant developed by Amazon",
           "tag": "Not available",


### PR DESCRIPTION
## Summary

Adds agent-qa to the **Developer** category. It is a self-improving QA agent for software teams, with natural-language web/mobile testing and persistent execution memory.

## Contributor checklist

- [x] Exactly one entry was added to `src/data/tools.json`
- [x] Description is five words and ends with a period
- [x] URL uses HTTPS and includes the required referral parameter
- [x] `date-added` uses `YYYY-MM-DD`
- [x] Slug was generated with the repository script
- [x] Branch follows `add-tool/<slug>`

## Validation

- `bun run add-slugs` — generated `agent-qa`
- `bun run check-data` — 1,131 entries checked, 0 issues
- `git diff --check` passes

Project disclosure: this submission is for agent-qa itself. Its current FSL-1.1-ALv2 license converts to Apache-2.0 after two years.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `Agent QA` tool to the Developer tools directory.
  * Included its quality-assurance description, free pricing, GitHub link, addition date, and searchable slug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->